### PR TITLE
Clone mingw-w64 using --depth 1

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -82,7 +82,7 @@ download_sources()
   cd "$src" || error_exit
 
   echo "downloading mingw-w64-git" >&3
-  git clone git://git.code.sf.net/p/mingw-w64/mingw-w64 "mingw-w64-git" || error_exit
+  git clone --depth 1 git://git.code.sf.net/p/mingw-w64/mingw-w64 "mingw-w64-git" || error_exit
 
   local urls=(
     "http://ftp.gnu.org/gnu/binutils/binutils-$v_binutils.tar.bz2"


### PR DESCRIPTION
Full git history is not necessary to run the build. This speed up the cloning process as well