### PR TITLE
Checkout from gcc-10.2.0 tag to avoid build failure on gcc-10 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Package
 * [MinGW-w64](https://mingw-w64.org) 7git
 * [Binutils](https://www.gnu.org/software/binutils/) 2.35git
-* [GCC](https://gcc.gnu.org/) 10git
+* [GCC](https://gcc.gnu.org/) 10.2.0
 * [GMP](https://gmplib.org/) 6.2.0
 * [MPFR](http://www.mpfr.org/) 4.1.0
 * [MPC](http://www.multiprecision.org/mpc/) 1.1.0

--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -19,7 +19,7 @@
 v_script="4git"
 v_mingww64="7git"
 v_binutils="2.35git"
-v_gcc="10git"
+v_gcc="10.2.0"
 v_gmp="6.2.0"
 v_mpfr="4.1.0"
 v_mpc="1.1.0"
@@ -90,7 +90,7 @@ download_sources()
   git clone --depth 1 -b binutils-2_35-branch git://sourceware.org/git/binutils-gdb.git binutils-$v_binutils || error_exit
 
   echo "downloading gcc" >&3
-  git clone --depth 1 -b releases/gcc-10 git://gcc.gnu.org/git/gcc.git gcc-$v_gcc || error_exit
+  git clone --depth 1 -b releases/gcc-$v_gcc git://gcc.gnu.org/git/gcc.git gcc-$v_gcc || error_exit
 
   local urls=(
     "https://ftp.gnu.org/gnu/gmp/gmp-$v_gmp.tar.xz"


### PR DESCRIPTION
gcc-10git failed to build, probably due to https://github.com/gcc-mirror/gcc/commit/3ec6a380bda3d2193925e1c017ea2739476cc125