### PR TITLE
Added xz as required prog.

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -235,6 +235,7 @@ progs=(
   "curl"
   "gzip"
   "bzip2"
+  "xz"
   "git"
   "make"
   "g++"


### PR DESCRIPTION
xz prog check was removed with afcde3dfd621d9845c6de8935583c2e0cd9ee211

But Debian's GNU tar wants a xz executable to extract *.xz archives.
I'm not sure if this is because it is GNU tar not BSD tar or just a Debian specific patch.

(using your script in a gitlab-ci lead to this build.log error)