### PR TITLE
Add i586 (pre-P6) support, shell script cleanups

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -26,6 +26,7 @@ ENABLE_THREADS="--enable-threads=posix"
 
 JOB_COUNT=$(($(getconf _NPROCESSORS_ONLN) + 2))
 
+BUILD_I586=0
 BUILD_I686=0
 BUILD_X86_64=0
 
@@ -38,7 +39,8 @@ Usage:
   $0 [options] <arch>...
 
 Archs:
-  i686    Windows 32-bit
+  i586    Windows 32-bit for old CPUs (Intel Pentium (MMX), AMD K5, K6, K6-2, K6-III)
+  i686    Windows 32-bit (Intel P6 [Pentium Pro], AMD K7 and newer)
   x86_64  Windows 64-bit
 
 Options:
@@ -161,10 +163,11 @@ build()
         remove_path "$prefix"
     fi
 
-    if [ "$arch" = "i686" ]; then
-        local i686_dwarf2="--disable-sjlj-exceptions --with-dwarf2"
+    if [ "$arch" = "i586" ] || [ "$arch" = "i686" ]; then
+        local x86_dwarf2="--disable-sjlj-exceptions --with-dwarf2"
         local crt_lib="--enable-lib32 --disable-lib64"
     else
+        local x86_dwarf2=""
         local crt_lib="--enable-lib64 --disable-lib32"
     fi
 
@@ -200,7 +203,7 @@ build()
         "$SRC_PATH/gcc/configure" --target="$host" --disable-shared \
             --enable-static --disable-multilib --prefix="$prefix" \
             --enable-languages=c,c++ --disable-nls $ENABLE_THREADS \
-            $i686_dwarf2
+            $x86_dwarf2
 
     execute "($arch): building GCC (all-gcc)" "" \
         make -j $JOB_COUNT all-gcc
@@ -352,6 +355,9 @@ while :; do
         --mingw-w64-branch=)
             arg_error "'--mingw-w64-branch' requires a non-empty option argument"
             ;;
+        i586)
+            BUILD_I586=1
+            ;;
         i686)
             BUILD_I686=1
             ;;
@@ -375,7 +381,7 @@ while :; do
     shift
 done
 
-NUM_BUILDS=$((BUILD_I686 + BUILD_X86_64))
+NUM_BUILDS=$((BUILD_I586 + BUILD_I686 + BUILD_X86_64))
 if [ "$NUM_BUILDS" -eq 0 ]; then
     arg_error "no ARCH was specified"
 fi
@@ -420,9 +426,11 @@ BLD_PATH="$ROOT_PATH/bld"
 LOG_FILE="$ROOT_PATH/build.log"
 
 if [ "$PREFIX" ]; then
+    I586_PREFIX="$PREFIX"
     I686_PREFIX="$PREFIX"
     X86_64_PREFIX="$PREFIX"
 else
+    I586_PREFIX="$ROOT_PATH/i586"
     I686_PREFIX="$ROOT_PATH/i686"
     X86_64_PREFIX="$ROOT_PATH/x86_64"
 fi
@@ -454,6 +462,11 @@ export CXXFLAGS="-g0"
 export LDFLAGS="-s"
 
 ADD_TO_PATH=()
+
+if [ "$BUILD_I586" ]; then
+    build i586 "$I586_PREFIX"
+    ADD_TO_PATH+=("'$I586_PREFIX/bin'")
+fi
 
 if [ "$BUILD_I686" ]; then
     build i686 "$I686_PREFIX"

--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -88,7 +88,7 @@ execute()
         printf "(%d/%d): %s\n" "$CURRENT_STEP" "$TOTAL_STEPS" "$info_msg"
         CURRENT_STEP=$((CURRENT_STEP + 1))
     fi
-    $@ >>"$LOG_FILE" 2>&1 || error_exit "$error_msg, check $LOG_FILE for details"
+    "$@" >>"$LOG_FILE" 2>&1 || error_exit "$error_msg, check $LOG_FILE for details"
 }
 
 create_dir()

--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -26,6 +26,9 @@ ENABLE_THREADS="--enable-threads=posix"
 
 JOB_COUNT=$(($(getconf _NPROCESSORS_ONLN) + 2))
 
+BUILD_I686=0
+BUILD_X86_64=0
+
 LINKED_RUNTIME="msvcrt"
 
 show_help()
@@ -372,7 +375,8 @@ while :; do
     shift
 done
 
-if [ ! "$BUILD_I686" ] && [ ! "$BUILD_X86_64" ]; then
+NUM_BUILDS=$((BUILD_I686 + BUILD_X86_64))
+if [ "$NUM_BUILDS" -eq 0 ]; then
     arg_error "no ARCH was specified"
 fi
 
@@ -402,12 +406,8 @@ else
     THREADS_STEPS=0
 fi
 
-if [ "$BUILD_I686" ] && [ "$BUILD_X86_64" ]; then
-    THREADS_STEPS=$((THREADS_STEPS * 2))
-    BUILD_STEPS=26
-else
-    BUILD_STEPS=13
-fi
+THREADS_STEPS=$((THREADS_STEPS * NUM_BUILDS))
+BUILD_STEPS=$((13 * NUM_BUILDS))
 
 TOTAL_STEPS=$((TOTAL_STEPS + THREADS_STEPS + BUILD_STEPS))
 

--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -453,22 +453,17 @@ export CFLAGS="-g0"
 export CXXFLAGS="-g0"
 export LDFLAGS="-s"
 
-COMPLETE_MSG="complete, to use MinGW-w64 everywhere add"
+ADD_TO_PATH=()
 
 if [ "$BUILD_I686" ]; then
     build i686 "$I686_PREFIX"
-    COMPLETE_MSG="$COMPLETE_MSG '$I686_PREFIX/bin'"
+    ADD_TO_PATH+=("'$I686_PREFIX/bin'")
 fi
 
 if [ "$BUILD_X86_64" ]; then
     build x86_64 "$X86_64_PREFIX"
-    if [ "$BUILD_I686" ]; then
-        COMPLETE_MSG="$COMPLETE_MSG and "
-    fi
-    COMPLETE_MSG="$COMPLETE_MSG '$X86_64_PREFIX/bin'"
+    ADD_TO_PATH+=("'$X86_64_PREFIX/bin'")
 fi
-
-COMPLETE_MSG="$COMPLETE_MSG to PATH."
 
 if [ ! "$KEEP_ARTIFACTS" ]; then
     remove_path "$SRC_PATH"
@@ -476,6 +471,9 @@ if [ ! "$KEEP_ARTIFACTS" ]; then
     remove_path "$LOG_FILE"
 fi
 
-printf "%s\n" "$COMPLETE_MSG"
+echo "complete, to use MinGW-w64 everywhere add these to your \$PATH:"
+for add_to_path in "${ADD_TO_PATH[@]}"; do
+    printf "\t%s\n" "$add_to_path"
+done
 
 exit 0


### PR DESCRIPTION
Add support for building a `i586-w64-mingw32` toolchain, which creates binaries without the P6-only `cmov` instructions (among other things). This should allow generation of binaries for really really old CPUs (pre-Pentium Pro, pre-K7/Athlon).

I have tested building a small example application using the toolchain and it seems to work fine with `wine` under Linux. Also, verified with `i586-w64-mingw32-objdump -d ... | grep cmov` that it indeed doesn't generate any `cmov` instructions where the `i686-w64-mingw32` toolchain does generate `cmov` instructions (have yet to test it on an old CPU).

As part of this addition, changed some shell script parts and fixed some `shellcheck` issues.