### PR TITLE
Add support for aarch64 builds

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -29,6 +29,7 @@ JOB_COUNT=$(($(getconf _NPROCESSORS_ONLN) + 2))
 BUILD_I586=0
 BUILD_I686=0
 BUILD_X86_64=0
+BUILD_AARCH64=0
 
 LINKED_RUNTIME="msvcrt"
 
@@ -41,7 +42,8 @@ Usage:
 Archs:
   i586    Windows 32-bit for old CPUs (Intel Pentium (MMX), AMD K5, K6, K6-2, K6-III)
   i686    Windows 32-bit (Intel P6 [Pentium Pro], AMD K7 and newer)
-  x86_64  Windows 64-bit
+  x86_64  Windows 64-bit (x86)
+  aarch64 Windows 64-bit (ARM)
 
 Options:
   -h, --help                   show help
@@ -364,6 +366,9 @@ while :; do
         x86_64)
             BUILD_X86_64=1
             ;;
+        aarch64)
+            BUILD_AARCH64=1
+            ;;
         --)
             shift
             break
@@ -381,7 +386,7 @@ while :; do
     shift
 done
 
-NUM_BUILDS=$((BUILD_I586 + BUILD_I686 + BUILD_X86_64))
+NUM_BUILDS=$((BUILD_I586 + BUILD_I686 + BUILD_X86_64 + BUILD_AARCH64))
 if [ "$NUM_BUILDS" -eq 0 ]; then
     arg_error "no ARCH was specified"
 fi
@@ -429,10 +434,12 @@ if [ "$PREFIX" ]; then
     I586_PREFIX="$PREFIX"
     I686_PREFIX="$PREFIX"
     X86_64_PREFIX="$PREFIX"
+    AARCH64_PREFIX="$PREFIX"
 else
     I586_PREFIX="$ROOT_PATH/i586"
     I686_PREFIX="$ROOT_PATH/i686"
     X86_64_PREFIX="$ROOT_PATH/x86_64"
+    AARCH64_PREFIX="$ROOT_PATH/aarch64"
 fi
 
 CURRENT_STEP=1
@@ -476,6 +483,11 @@ fi
 if [ "$BUILD_X86_64" ]; then
     build x86_64 "$X86_64_PREFIX"
     ADD_TO_PATH+=("'$X86_64_PREFIX/bin'")
+fi
+
+if [ "$BUILD_AARCH64" ]; then
+    build aarch64 "$AARCH64_PREFIX"
+    ADD_TO_PATH+=("'$AARCH64_PREFIX/bin'")
 fi
 
 if [ ! "$KEEP_ARTIFACTS" ]; then


### PR DESCRIPTION
This doesn't work yet and has not been tested, but GCC already supports aarch64 (obviously), and there's an aarch64 build of e.g. Windows 11 that runs on Parallels for Mac. I guess don't merge yet until this has been verified working, but since I wrote it for testing (didn't end up working...) I thought I might throw this in here before just removing the test code :)