### PR TITLE
Fix build conditions for architectures

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -26,10 +26,6 @@ ENABLE_THREADS="--enable-threads=posix"
 
 JOB_COUNT=$(($(getconf _NPROCESSORS_ONLN) + 2))
 
-BUILD_I586=0
-BUILD_I686=0
-BUILD_X86_64=0
-
 LINKED_RUNTIME="msvcrt"
 
 show_help()


### PR DESCRIPTION
This bug was introduced with my i586 changes, and it apparently never worked correctly, because:

```
[ "0" ]; echo $?
```

(this prints `0` as in exit code zero, meaning `"0"` evaluates to something true-ish here)

To fix this, use:

```
[ "0" -ne 0 ]; echo $?
```

(this prints `1`, as in false-ish)

```
[ "1" -ne 0 ]; echo $?
```

(this prints `0`, as in true-ish)

(I didn't really get to test this, as I was always building for all architectures..)