### PR TITLE
Allow setting _WIN32_WINNT for targetting older Windows API versions

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -21,7 +21,7 @@ ROOT_PATH="$HOME/.zeranoe/mingw-w64"
 MINGW_W64_BRANCH="master"
 BINUTILS_BRANCH="binutils-2_42-branch"
 GCC_BRANCH="releases/gcc-14"
-WIN32_WINNT="0xa00"
+WIN32_WINNT="0xA00"
 
 ENABLE_THREADS="--enable-threads=posix"
 
@@ -54,19 +54,8 @@ Options:
   --linked-runtime <runtime>   set MinGW Linked Runtime (default: $LINKED_RUNTIME)
   --win32-winnt <version>      set default _WIN32_WINNT value (default: $WIN32_WINNT)
 
-Possible _WIN32_WINNT values:
-
-  0x0400 (Windows NT 4.0)
-  0x0500 (Windows 2000)
-  0x0501 (Windows XP)
-  0x0502 (Windows Server 2003)
-  0x0600 (Windows Vista)
-  0x0601 (Windows 7)
-  0x0602 (Windows 8)
-  0x0603 (Windows 8.1)
-  0x0A00 (Windows 10)
-
-See also: https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
+For possible _WIN32_WINNT values, see:
+https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
 
 EOF
 }
@@ -380,7 +369,7 @@ while :; do
         --win32-winnt=?*)
             WIN32_WINNT=${1#*=}
             ;;
-        --WIN32_WINNT=)
+        --win32-winnt=)
             arg_error "'--win32-winnt' requires a non-empty option argument"
             ;;
         i586)

--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -21,6 +21,7 @@ ROOT_PATH="$HOME/.zeranoe/mingw-w64"
 MINGW_W64_BRANCH="master"
 BINUTILS_BRANCH="binutils-2_42-branch"
 GCC_BRANCH="releases/gcc-14"
+WIN32_WINNT="0xa00"
 
 ENABLE_THREADS="--enable-threads=posix"
 
@@ -51,6 +52,22 @@ Options:
   --gcc-branch <branch>        set GCC branch (default: $GCC_BRANCH)
   --mingw-w64-branch <branch>  set MinGW-w64 branch (default: $MINGW_W64_BRANCH)
   --linked-runtime <runtime>   set MinGW Linked Runtime (default: $LINKED_RUNTIME)
+  --win32-winnt <version>      set default _WIN32_WINNT value (default: $WIN32_WINNT)
+
+Possible _WIN32_WINNT values:
+
+  0x0400 (Windows NT 4.0)
+  0x0500 (Windows 2000)
+  0x0501 (Windows XP)
+  0x0502 (Windows Server 2003)
+  0x0600 (Windows Vista)
+  0x0601 (Windows 7)
+  0x0602 (Windows 8)
+  0x0603 (Windows 8.1)
+  0x0A00 (Windows 10)
+
+See also: https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt
+
 EOF
 }
 
@@ -187,6 +204,7 @@ build()
     execute "($arch): configuring MinGW-w64 headers" "" \
         "$SRC_PATH/mingw-w64/mingw-w64-headers/configure" --build="$BUILD" \
             --host="$host" --prefix="$prefix/$host" \
+            --with-default-win32-winnt=$WIN32_WINNT \
             --with-default-msvcrt=$LINKED_RUNTIME
 
     execute "($arch): installing MinGW-w64 headers" "" \
@@ -350,6 +368,20 @@ while :; do
             ;;
         --mingw-w64-branch=)
             arg_error "'--mingw-w64-branch' requires a non-empty option argument"
+            ;;
+        --win32-winnt)
+            if [ "$2" ]; then
+                WIN32_WINNT="$2"
+                shift
+            else
+                arg_error "'--win32-winnt' requires a non-empty option argument"
+            fi
+            ;;
+        --win32-winnt=?*)
+            WIN32_WINNT=${1#*=}
+            ;;
+        --WIN32_WINNT=)
+            arg_error "'--win32-winnt' requires a non-empty option argument"
             ;;
         i586)
             BUILD_I586=1


### PR DESCRIPTION
The default version has been changed to Windows 10 in mingw-w64 8.0.1 and newer (https://github.com/mirror/mingw-w64/commit/f3c53a51df5c08f181e13a39b1cd6fd1d41edb96) and was Windows Server 2003 before that.

This patch allows optionally building a toolchain that can target older versions of Windows.

The article [Update WINVER and _WIN32_WINNT](https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170) on Microsoft Learn has some details on the possible values.

Building the toolchain for an older version of Windows will still make the resulting binaries work on newer versions, but new APIs introduced after that version won't be used.