### PR TITLE
Fix downloading config.guess.

### DIFF
--- a/mingw-w64-build
+++ b/mingw-w64-build
@@ -145,7 +145,7 @@ download_sources()
 
     execute "downloading config.guess" "" \
         curl -o config.guess \
-            "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"
+            "https://gitweb.git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD"
 }
 
 build()


### PR DESCRIPTION
The domain used to download this file changed at some point, and a redirection was put into place. However, that leads to curl downloading a HTML file instead of following that redirection.

This PR fixes that.